### PR TITLE
Update to ScriptThread.cs

### DIFF
--- a/ScriptCore/Game/ScriptThread.cs
+++ b/ScriptCore/Game/ScriptThread.cs
@@ -18,7 +18,7 @@ namespace ScriptCore
         /// </summary>
         private static ScriptVarCollection _vars;
 
-        protected ScriptThread()
+        Public ScriptThread()
         {
             _extensions = new ScriptExtensionPool();
             _vars = new ScriptVarCollection();


### PR DESCRIPTION
I was told to try changing "protected ScriptThread.cs ()" to "Public ScriptThread.cs () in hopes to try to get the tornado to pick objects up. I get "[ERROR] Failed to instantiate script 'ScriptCore.ScriptThread' because no public default constructor was found."